### PR TITLE
ci: fix yarn version command conflict in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,8 @@ jobs:
         uses: changesets/action@v1
         with:
           # This expects you to have a script called version which updates the lockfile after calling `changeset version`.
-          version: yarn version
+          # Use "yarn run version" to call the npm script (not Yarn 4's built-in "yarn version" command)
+          version: yarn run version
           # This expects you to have a script called release which builds your packages and then calls `changeset publish`.
           publish: yarn release
         env:


### PR DESCRIPTION
## Summary
- Fix the release workflow to use `yarn run version` instead of `yarn version`
- In Yarn 4, `yarn version` is a built-in command for managing versions, which conflicts with our npm script named `version`
- Using `yarn run version` explicitly calls the npm script in package.json

## Test plan
- [x] Local verification of script
- [ ] CI passes
- [ ] Release workflow succeeds after merge