### PR TITLE
fix: use YARN_NPM_AUTH_TOKEN for registry auth in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    env:
+      # Yarn 4 reads auth token from this env var for the @heygrady scope
+      YARN_NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
       - name: Enable Corepack
@@ -22,13 +25,6 @@ jobs:
           cache: 'yarn'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@heygrady'
-      - name: Setup .yarnrc.yml
-        run: |
-          yarn config set npmScopes.heygrady.npmRegistryServer "https://npm.pkg.github.com"
-          yarn config set npmScopes.heygrady.npmAlwaysAuth true
-          yarn config set npmScopes.heygrady.npmAuthToken $NPM_AUTH_TOKEN
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache dependencies and Turbo
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- Remove the dynamic `.yarnrc.yml` modification step which was lost when changesets action does `git reset --hard`
- Use `YARN_NPM_AUTH_TOKEN` environment variable at job level so Yarn 4 can authenticate with GitHub Package Registry
- This ensures auth works even after changesets checks out the release branch

## Test plan
- [ ] CI passes
- [ ] Release workflow succeeds and creates Version Packages PR