### PR TITLE
docs: improve README documentation across all packages

### DIFF
--- a/.changeset/bright-docs-shine.md
+++ b/.changeset/bright-docs-shine.md
@@ -1,0 +1,8 @@
+---
+"@heygrady/blog-app": patch
+"@heygrady/eslint-config": patch
+"@heygrady/jest-preset-ts-node-esm": patch
+"@heygrady/tsconfig-bases": patch
+---
+
+Improve README documentation with installation instructions, usage examples, and Yarn/npm configuration for GitHub Packages

--- a/README.md
+++ b/README.md
@@ -1,9 +1,89 @@
-# blog
+# @heygrady/blog
 
 My [blog](https://heygrady.com/). Built with [Astro](https://astro.build/). A rebuild of my [Gatsby blog](https://github.com/heygrady/blog/blob/c5660d45c348d87967ce511dde22442743b87100/README.md), itself a rebuild of my [Octopress blog](https://2012.heygrady.com/).
 
 Read about [relaunching on Astro](https://heygrady.com/posts/2022-08-29-relaunching-on-astro) on the blog.
 
-Previous posts:
+## Monorepo Structure
+
+This is a Yarn 4 monorepo using [Turborepo](https://turbo.build/) for task orchestration.
+
+```
+apps/
+  blog-app/           # Main Astro blog (heygrady.com)
+
+packages/
+  eslint-config/      # Shared ESLint flat config for ESLint 9+
+  jest-preset-ts-node-esm/  # Jest preset for TypeScript ESM projects
+  tsconfig-bases/     # Shared TypeScript configurations
+
+scripts/
+  create-post/        # CLI tool for creating new blog posts
+
+templates/
+  node-esm/           # Package template for Node.js ESM
+  ts-node-esm/        # Package template for TypeScript ESM
+```
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 20+ (managed via [Volta](https://volta.sh/))
+- Yarn 4
+
+### Installation
+
+```bash
+yarn install
+```
+
+### Development
+
+```bash
+# Start the blog dev server
+yarn dev
+
+# Build all packages
+yarn build
+
+# Run linting
+yarn lint
+yarn format
+
+# Run tests
+yarn test
+```
+
+### Creating a New Post
+
+```bash
+yarn create-post
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `yarn start` | Start the blog dev server |
+| `yarn build` | Build all packages |
+| `yarn lint` | Lint all packages |
+| `yarn format` | Lint and fix all packages |
+| `yarn test` | Run tests across all packages |
+| `yarn coverage` | Run tests with coverage |
+| `yarn create-post` | Create a new blog post |
+| `yarn clean` | Clean turbo cache |
+| `yarn clean:hard` | Full clean including node_modules |
+
+## Release Workflow
+
+This repo uses [Changesets](https://github.com/changesets/changesets) for version management and publishes packages to [GitHub Package Registry](https://github.com/features/packages).
+
+## Deployment
+
+The blog is deployed to [Firebase Hosting](https://firebase.google.com/docs/hosting). Production deploys happen automatically when the "Version Packages" PR is merged to main.
+
+## Previous Posts
+
 - [Updating my blog to Gatsby](https://heygrady.com/posts/2017-06-30-new-blog)
 - [Migrating the old site](https://heygrady.com/posts/2017-06-30-migrating-old-site)

--- a/apps/blog-app/README.md
+++ b/apps/blog-app/README.md
@@ -1,64 +1,57 @@
-# Astro Starter Kit: Blog
+# @heygrady/blog-app
 
-```
-npm init astro -- --template blog
-```
+The main Astro blog application for [heygrady.com](https://heygrady.com/).
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/blog)
+## Features
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+- Built with [Astro](https://astro.build/) 5
+- Markdown & MDX support for blog posts
+- SEO-friendly with canonical URLs and OpenGraph data
+- Sitemap and RSS feed support
+- Image optimization with Sharp
+- Deployed to Firebase Hosting
 
+## Development
 
-![blog](https://user-images.githubusercontent.com/4677417/186189140-4ef17aac-c3c9-4918-a8c2-ce86ba1bb394.png)
+This package is part of a Yarn monorepo. Run commands from the monorepo root:
 
-Features:
+```bash
+# Start the dev server (localhost:4321)
+yarn start
 
-- ✅ Minimal styling (make it your own!)
-- ✅ 100/100 Lighthouse performance
-- ✅ SEO-friendly with canonical URLs and OpenGraph data
-- ✅ Sitemap support
-- ✅ RSS Feed support
-- ✅ Markdown & MDX support
+# Build for production
+yarn build
 
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
-
-```
-├── public/
-├── src/
-│   ├── components/
-│   ├── layouts/
-│   └── pages/
-├── astro.config.mjs
-├── README.md
-├── package.json
-└── tsconfig.json
+# Preview the production build
+yarn workspace @heygrady/blog-app preview
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+## Project Structure
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+```
+src/
+├── components/     # Astro/React components
+├── layouts/        # Page layouts
+├── pages/
+│   └── posts/      # Blog posts as Markdown files
+└── styles/         # Global styles
+public/             # Static assets
+```
 
-Any static assets, like images, can be placed in the `public/` directory.
+## Creating Posts
 
-## 🧞 Commands
+Blog posts are Markdown files in `src/pages/posts/` with date-prefixed filenames:
 
-All commands are run from the root of the project, from a terminal:
+```
+2023-07-28-my-post-title.md
+```
 
-| Command                | Action                                           |
-| :--------------------- | :----------------------------------------------- |
-| `npm install`          | Installs dependencies                            |
-| `npm run dev`          | Starts local dev server at `localhost:3000`      |
-| `npm run build`        | Build your production site to `./dist/`          |
-| `npm run preview`      | Preview your build locally, before deploying     |
-| `npm run astro ...`    | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro --help` | Get help using the Astro CLI                     |
+Use the monorepo's create-post command to scaffold new posts:
 
-## 👀 Want to learn more?
+```bash
+yarn create-post
+```
 
-Check out [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+## Deployment
 
-## Credit
-
-This theme is based off of the lovely [Bear Blog](https://github.com/HermanMartinus/bearblog/).
+The blog is deployed to Firebase Hosting. Production deploys happen automatically when the "Version Packages" PR is merged to main.

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -6,19 +6,32 @@ My personal, shared [ESLint](https://eslint.org/) configuration for ESLint 9+ wi
 
 This package is hosted on [GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry). You'll need to configure your package manager to use the GitHub Packages registry for the `@heygrady` scope.
 
-Create a `.npmrc` file in your project root with the following content:
+### Yarn (v2+)
 
-```
-@heygrady:registry=https://npm.pkg.github.com
+Add to your `.yarnrc.yml`:
+
+```yaml
+npmScopes:
+  heygrady:
+    npmAlwaysAuth: true
+    npmRegistryServer: "https://npm.pkg.github.com"
 ```
 
-Then, install the package:
+Then install:
 
 ```bash
 yarn add -D eslint @heygrady/eslint-config
 ```
 
-or with npm:
+### npm
+
+Create a `.npmrc` file in your project root:
+
+```
+@heygrady:registry=https://npm.pkg.github.com
+```
+
+Then install:
 
 ```bash
 npm install --save-dev eslint @heygrady/eslint-config
@@ -77,6 +90,45 @@ import astro from '@heygrady/eslint-config/astro'
 
 export default [
   ...astro,
+]
+```
+
+### Astro + React
+
+For Astro projects using React components.
+
+```js
+// eslint.config.mjs
+import astroReact from '@heygrady/eslint-config/astro-react'
+
+export default [
+  ...astroReact,
+]
+```
+
+### Astro + Solid
+
+For Astro projects using SolidJS components.
+
+```js
+// eslint.config.mjs
+import astroSolid from '@heygrady/eslint-config/astro-solid'
+
+export default [
+  ...astroSolid,
+]
+```
+
+### TypeScript + Solid
+
+For TypeScript projects using SolidJS (ES Modules).
+
+```js
+// eslint.config.mjs
+import tsxSolidEsm from '@heygrady/eslint-config/tsx-solid-esm'
+
+export default [
+  ...tsxSolidEsm,
 ]
 ```
 

--- a/packages/jest-preset-ts-node-esm/README.md
+++ b/packages/jest-preset-ts-node-esm/README.md
@@ -1,1 +1,89 @@
 # @heygrady/jest-preset-ts-node-esm
+
+A Jest preset for TypeScript projects using ES Modules.
+
+## Installation
+
+This package is hosted on [GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry). Configure your package manager to use the GitHub Packages registry for the `@heygrady` scope.
+
+### Yarn (v2+)
+
+Add to your `.yarnrc.yml`:
+
+```yaml
+npmScopes:
+  heygrady:
+    npmAlwaysAuth: true
+    npmRegistryServer: "https://npm.pkg.github.com"
+```
+
+Then install:
+
+```bash
+yarn add -D @heygrady/jest-preset-ts-node-esm
+```
+
+### npm
+
+Create a `.npmrc` file:
+
+```
+@heygrady:registry=https://npm.pkg.github.com
+```
+
+Then install:
+
+```bash
+npm install --save-dev @heygrady/jest-preset-ts-node-esm
+```
+
+## Usage
+
+Create a `jest.config.js` file in your project:
+
+```js
+module.exports = {
+  preset: '@heygrady/jest-preset-ts-node-esm',
+}
+```
+
+Or extend it in `jest.config.mjs`:
+
+```js
+import preset from '@heygrady/jest-preset-ts-node-esm'
+
+export default {
+  ...preset,
+  // your overrides here
+}
+```
+
+## Features
+
+- Uses [ts-jest](https://kulshekhar.github.io/ts-jest/) with ESM support
+- Configures `ts-jest-resolver` for proper module resolution
+- Supports TypeScript extensions: `.ts`, `.tsx`, `.cts`, `.mts`
+- Supports JavaScript extensions: `.js`, `.jsx`, `.cjs`, `.mjs`
+- Includes mocks for static assets (images, fonts, styles)
+- CSS Modules support via `identity-obj-proxy`
+- Default coverage thresholds: 75% for branches, functions, lines, and statements
+
+## Test File Location
+
+By default, tests should be placed in a `test/` directory with `.spec.ts` or `.spec.tsx` extensions:
+
+```
+test/
+├── example.spec.ts
+└── component.spec.tsx
+```
+
+## Coverage
+
+Run tests with coverage:
+
+```bash
+jest --coverage
+```
+
+Coverage reports are output to `coverage/` directory.

--- a/packages/tsconfig-bases/README.md
+++ b/packages/tsconfig-bases/README.md
@@ -1,1 +1,116 @@
 # @heygrady/tsconfig-bases
+
+Shared TypeScript configuration bases for various project types.
+
+## Installation
+
+This package is hosted on [GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry). Configure your package manager to use the GitHub Packages registry for the `@heygrady` scope.
+
+### Yarn (v2+)
+
+Add to your `.yarnrc.yml`:
+
+```yaml
+npmScopes:
+  heygrady:
+    npmAlwaysAuth: true
+    npmRegistryServer: "https://npm.pkg.github.com"
+```
+
+Then install:
+
+```bash
+yarn add -D @heygrady/tsconfig-bases
+```
+
+### npm
+
+Create a `.npmrc` file:
+
+```
+@heygrady:registry=https://npm.pkg.github.com
+```
+
+Then install:
+
+```bash
+npm install --save-dev @heygrady/tsconfig-bases
+```
+
+## Available Configurations
+
+### TypeScript + Node.js (ESM)
+
+For TypeScript projects running in Node.js with ES Modules.
+
+```json
+{
+  "extends": "@heygrady/tsconfig-bases/ts-node-esm/tsconfig.json"
+}
+```
+
+Extends: `@tsconfig/node24`, `@tsconfig/strictest`
+
+### TypeScript + React (ESM)
+
+For TypeScript projects using React with Vite.
+
+```json
+{
+  "extends": "@heygrady/tsconfig-bases/tsx-react-esm/tsconfig.json"
+}
+```
+
+Extends: `@tsconfig/vite-react`, `@tsconfig/strictest`
+
+### TypeScript + Solid (ESM)
+
+For TypeScript projects using SolidJS.
+
+```json
+{
+  "extends": "@heygrady/tsconfig-bases/tsx-solid-esm/tsconfig.json"
+}
+```
+
+Extends: `@tsconfig/vite-react`, `@tsconfig/strictest` (with JSX preserve for Solid)
+
+### TypeScript Web (ESNext)
+
+For TypeScript web projects targeting modern browsers.
+
+```json
+{
+  "extends": "@heygrady/tsconfig-bases/ts-web-esnext/tsconfig.json"
+}
+```
+
+Extends: `@tsconfig/vite-react`, `@tsconfig/strictest`
+
+## Common Settings
+
+All configurations include these defaults:
+
+- `allowJs: true` - Allow JavaScript files
+- `checkJs: false` - Don't type-check JavaScript files
+- `declaration: false` - Don't emit declaration files (override as needed)
+- `noEmit: true` - Type-checking only by default
+- `isolatedModules: true` - Required for tools like esbuild/swc
+- Strict mode enabled via `@tsconfig/strictest`
+- Default includes: `src`, `test`
+- Default excludes: `node_modules`, `dist`
+
+## Customizing
+
+Extend a base and override as needed:
+
+```json
+{
+  "extends": "@heygrady/tsconfig-bases/ts-node-esm/tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}
+```


### PR DESCRIPTION
## Summary
- Update root README with monorepo structure, commands, and getting started guide
- Replace blog-app boilerplate README with project-specific documentation
- Add comprehensive documentation to eslint-config including missing configs (astro-react, astro-solid, tsx-solid-esm)
- Create full documentation for jest-preset-ts-node-esm with features and usage
- Create full documentation for tsconfig-bases with all available configurations
- Add Yarn (v2+) installation instructions alongside npm for GitHub Packages

## Test plan
- [ ] Verify all README files render correctly on GitHub
- [ ] Check Firebase preview deploy